### PR TITLE
Repository migration follow ups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,6 @@ on:
 permissions:
   contents: read
 
-env:
-  IMAGE_NAME: gh-workflow-stats-action
-
 jobs:
   docker:
     runs-on: ubuntu-latest
@@ -24,8 +21,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images:
-            ${{ vars.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}
+          images: neondatabase/gh-workflow-stats-action
           tags: |
             # branch event
             type=ref,enable=true,priority=600,prefix=,suffix=,event=branch
@@ -42,8 +38,8 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ vars.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.NEON_DOCKERHUB_USERNAME }}
+          password: ${{ secrets.NEON_DOCKERHUB_PASSWORD }}
 
       - name: Build and publish
         uses: docker/build-push-action@v6

--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ inputs:
 
 runs:
   using: docker
-  image: "docker://yatheo/gh-workflow-stats-action:v0.1.4"
+  image: "docker://neondatabase/gh-workflow-stats-action:v0.1.4"
   env:
     DB_URI: ${{ inputs.db_uri }}
     DB_TABLE: ${{ inputs.db_table }}

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/fedordikarev/gh-workflow-stats-action
+module github.com/neondatabase/gh-workflow-stats-action
 
 go 1.23.1
 


### PR DESCRIPTION
- `docker://yatheo` -> `docker://neondatabase` (including pushing images in CI to the new repo)
- `github.com/fedordikarev` -> `github.com/neondatabase` 
