### PR TITLE
Make history-exporter default action

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,10 +20,10 @@ COPY go.mod go.sum ./
 RUN go mod download
 
 COPY pkg/ pkg/
-COPY cmd/gh-action/ ./
+COPY cmd/history-exporter/ ./
 
 ENV CGO_ENABLED=0
-RUN go build -v -o ./gh-action-workflow-stats
+RUN go build -v -o ./gh-action-history-exporter
 
 
 FROM scratch
@@ -36,9 +36,9 @@ COPY --from=go-build /etc/passwd /etc/group /etc/
 USER gh-action:gh-action
 
 # Copy the static executable
-COPY --from=go-build /build/gh-action-workflow-stats /gh-action-workflow-stats
+COPY --from=go-build /build/gh-action-history-exporter /gh-action-history-exporter
 
 # Run the binary
-ENTRYPOINT ["/gh-action-workflow-stats"]
+ENTRYPOINT ["/gh-action-history-exporter"]
 
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
 # Github Workflow Stats exporter to Postgres
 
+## WIP
+Work is in progress so list of parameters could be changed.
+
 ## Inputs
 
-| Input               | Description                            |
-| ------------------- | -------------------------------------- |
-| `DB_URI`            | Database URI                           |
-| `DB_TABLE`          | Table for storing Workflow stats       |
-| `GH_RUN_ID`         | Workflow Run Id to get information on  |
-| `GH_TOKEN`          | Github Token, optional for public Repo |
+| Input               | Description                               |
+| ------------------- | ----------------------------------------- |
+| `db_uri`            | Database URI                              |
+| `db_table`          | Table for storing Workflow stats          |
+| `gh_run_id`         | Workflow Run Id to get information on     |
+| `gh_token`          | Github Token, optional for public Repo    |
+| `duration`          | Duration for the history period to export |

--- a/action.yml
+++ b/action.yml
@@ -30,7 +30,7 @@ inputs:
 
 runs:
   using: docker
-  image: "docker://neondatabase/gh-workflow-stats-action:v0.2.0"
+  image: "docker://neondatabase/gh-workflow-stats-action:v0.2.1"
   args:
     - -duration=${{ inputs.duration }}
     - -exit-on-token-rate-limit=${{ inputs.exit_on_token_rate_limit }}

--- a/action.yml
+++ b/action.yml
@@ -19,10 +19,16 @@ inputs:
   gh_token:
     description: Github Token with permissions to access Workflows. Not required for public repos.
     required: false
+  duration:
+    description: Duration for the history period to export (in Golang time.parseDuration format)
+    required: false
+    default: '1h'
 
 runs:
   using: docker
-  image: "docker://neondatabase/gh-workflow-stats-action:v0.1.4"
+  image: "docker://neondatabase/gh-workflow-stats-action:v0.2.0"
+  args:
+    - -duration=${{ inputs.duration }}
   env:
     DB_URI: ${{ inputs.db_uri }}
     DB_TABLE: ${{ inputs.db_table }}

--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ inputs:
     required: true
   gh_run_id:
     description: Workflow Run Id to get information on
-    required: true
+    required: false
   gh_token:
     description: Github Token with permissions to access Workflows. Not required for public repos.
     required: false

--- a/action.yml
+++ b/action.yml
@@ -23,12 +23,17 @@ inputs:
     description: Duration for the history period to export (in Golang time.parseDuration format)
     required: false
     default: '1h'
+  exit_on_token_rate_limit:
+    description: Do not sleep and just exit when we used github token rate limit
+    required: false
+    default: 'true'
 
 runs:
   using: docker
   image: "docker://neondatabase/gh-workflow-stats-action:v0.2.0"
   args:
     - -duration=${{ inputs.duration }}
+    - -exit-on-token-rate-limit=${{ inputs.exit_on_token_rate_limit }}
   env:
     DB_URI: ${{ inputs.db_uri }}
     DB_TABLE: ${{ inputs.db_table }}

--- a/cmd/history-exporter/main.go
+++ b/cmd/history-exporter/main.go
@@ -102,6 +102,10 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+	err = db.InitDatabase(conf)
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	gh.InitGhClient(&conf)
 	ctx := context.Background()
@@ -125,10 +129,11 @@ func main() {
 			len(runs), len(notInDb),
 		)
 		if rate.Remaining < 30 {
+			fmt.Printf("Close to rate limit, remaining: %d", rate.Remaining)
 			if exitOnTokenRateLimit {
+				fmt.Printf("Exit due to the flag -exit-on-token-rate-limit=true")
 				break
 			}
-			fmt.Printf("Close to rate limit, remaining: %d", rate.Remaining)
 			fmt.Printf("Sleep till %v (%v seconds)\n", rate.Reset, time.Until(rate.Reset.Time))
 			time.Sleep(time.Until(rate.Reset.Time))
 		} else {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -46,12 +46,14 @@ func GetConfig() (ConfigType, error) {
 
 	envRunID := os.Getenv("GH_RUN_ID")
 	var runID int64
-	if len(envRunID) == 0 {
-		return ConfigType{}, fmt.Errorf("missing env: GH_RUN_ID")
-	}
-	runID, err := strconv.ParseInt(envRunID, 10, 64)
-	if err != nil {
-		return ConfigType{}, fmt.Errorf("GH_RUN_ID must be integer, error: %v", err)
+	if len(envRunID) > 0 {
+		var err error
+		runID, err = strconv.ParseInt(envRunID, 10, 64)
+		if err != nil {
+			return ConfigType{}, fmt.Errorf("GH_RUN_ID must be integer, error: %v", err)
+		}
+	} else {
+		runID = -1
 	}
 
 	githubToken := os.Getenv("GH_TOKEN")

--- a/pkg/export/export.go
+++ b/pkg/export/export.go
@@ -11,13 +11,17 @@ import (
 	"github.com/neondatabase/gh-workflow-stats-action/pkg/gh"
 )
 
-func ExportAndSaveJobs(ctx context.Context, conf config.ConfigType, runAttempt int64) error {
+func ExportAndSaveJobs(ctx context.Context, conf config.ConfigType, runAttempt int64, exitOnTokenRateLimit bool) error {
 	jobsInfo, rate, err := gh.GetWorkflowAttemptJobs(ctx, conf, runAttempt)
 	if err != nil {
 		log.Fatal(err)
 	}
 	if rate.Remaining < 20 {
 		fmt.Printf("Close to rate limit, remaining: %d", rate.Remaining)
+		if exitOnTokenRateLimit {
+			fmt.Printf("Exit due to the flag -exit-on-token-rate-limit=true")
+			return nil
+		}
 		fmt.Printf("Sleep till %v (%v seconds)\n", rate.Reset, time.Until(rate.Reset.Time))
 		time.Sleep(time.Until(rate.Reset.Time))
 	}


### PR DESCRIPTION
As we found it's much better to export stats in a batch, so lets make history-exporter default binary for the action.

That will break backward compatibility, just we expect we are the only users of this action so far, so it should be fine.