### PR TITLE
workaround for ARGS doesn't work in ENTRYPOINT

### DIFF
--- a/Dockerfiles/go-app-common.Dockerfile
+++ b/Dockerfiles/go-app-common.Dockerfile
@@ -12,6 +12,6 @@ FROM --platform=$TARGETPLATFORM ${BASE_IMAGE_SHA}
 ARG BINARY_TO_ADD
 
 ADD ${BINARY_TO_ADD} /usr/local/bin/
-RUN ln -s /usr/local/bin/${BINARY_TO_ADD} /entrypoint_executable
+RUN ln -s /usr/local/bin/${BINARY_TO_ADD} /usr/local/bin/entrypoint
 
-ENTRYPOINT ["/entrypoint_executable"]
+ENTRYPOINT ["/usr/local/bin/entrypoint"]

--- a/Dockerfiles/go-app-common.Dockerfile
+++ b/Dockerfiles/go-app-common.Dockerfile
@@ -12,5 +12,6 @@ FROM --platform=$TARGETPLATFORM ${BASE_IMAGE_SHA}
 ARG BINARY_TO_ADD
 
 ADD ${BINARY_TO_ADD} /usr/local/bin/
+RUN ln -s /usr/local/bin/${BINARY_TO_ADD} /entrypoint_executable
 
-ENTRYPOINT ["/usr/local/bin/${BINARY_TO_ADD}"]
+ENTRYPOINT ["/entrypoint_executable"]


### PR DESCRIPTION
Apply workaround from the https://github.com/moby/moby/issues/18492#issuecomment-347364597
Here is the issue in `moby/buildkit` https://github.com/moby/buildkit/issues/4881

and so far no better solution.
Issue is that `ARG`s are not expanded in the `ENTRYPOINT` section, so there we must use some static name.
And to make it works, lets create symlink with the name `/entrypoint_executable`, that will point to the actual binary in the image.