### PR TITLE
install ca-certificates into Docker image

### DIFF
--- a/Dockerfiles/go-app-common.Dockerfile
+++ b/Dockerfiles/go-app-common.Dockerfile
@@ -11,6 +11,8 @@ ARG BASE_IMAGE_SHA=debian@$BOOKWORM_SLIM_SHA
 FROM --platform=$TARGETPLATFORM ${BASE_IMAGE_SHA}
 ARG BINARY_TO_ADD
 
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/*
+
 ADD ${BINARY_TO_ADD} /usr/local/bin/
 RUN ln -s /usr/local/bin/${BINARY_TO_ADD} /usr/local/bin/entrypoint
 


### PR DESCRIPTION
To fix the issue:
```
request failed: Get "https://api.github.com/repos/neondatabase/neon/actions/runs?created=2025-03-31T08%3A03%3A00Z..2025-03-31T09%3A03%3A00Z&per_page=100&status=completed": tls: failed to verify certificate: x509: certificate signed by unknown authority
```