### PR TITLE
Replace dorny/paths-filter with step-security maintained version

### DIFF
--- a/.github/workflows/00_pull-request-entry-point.yml
+++ b/.github/workflows/00_pull-request-entry-point.yml
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Go Projects Changes
         id: go-projects-changes
-        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36  #v3
+        uses: step-security/paths-filter@v3
         with:
           token: ${{ github.token }}
           filters: .github/file-filters/go-components.yaml


### PR DESCRIPTION
Our CI/CD security tool StepSecurity maintains safer forks of popular GitHub Actions with low security scores. We're replacing ```dorny/paths-filter``` with the maintained ```step-security/paths-filter``` version to reduce risk of supply chain breaches and potential CVEs. 

This PR will fix: https://github.com/neondatabase/cloud/issues/26141