### PR TITLE
Revert "Replace dorny/paths-filter with step-security maintained version"

### DIFF
--- a/.github/workflows/00_pull-request-entry-point.yml
+++ b/.github/workflows/00_pull-request-entry-point.yml
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Go Projects Changes
         id: go-projects-changes
-        uses: step-security/paths-filter@v3
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36  #v3
         with:
           token: ${{ github.token }}
           filters: .github/file-filters/go-components.yaml


### PR DESCRIPTION
Reverts neondatabase/gh-workflow-stats-action#42

Step Security is not yet approved by Databricks team, in order to prevent issues during Github org migration, I'll revert this PR to use the previous action instead of Step Security maintained action.