### PR TITLE
fix docker-login action version

### DIFF
--- a/.github/workflows/push-main-docker.yml
+++ b/.github/workflows/push-main-docker.yml
@@ -17,7 +17,7 @@ jobs:
       uses: docker/setup-buildx-action@0d103c3126aa41d772a8362f6aa67afac040f80c  # v3.1.0
 
     - name: Log in to GHCR
-      uses: docker/login-action@a255b75080347930014286262037724911147073  # v3.1.0
+      uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772  # v3.4.0
       with:
         registry: ghcr.io
         username: ${{ github.actor }}


### PR DESCRIPTION
That will fix broken login action:
https://github.com/neondatabase/gh-workflow-stats-action/actions/runs/18032562405/job/51312103920
```
Download action repository 'docker/login-action@a255b75080347930014286262037724911147073' (SHA:a255b75080347930014286262037724911147073)
Error: An action could not be found at the URI 'https://api.github.com/repos/docker/login-action/tarball/a255b75080347930014286262037724911147073' (DF82:F0868:1062E7:1646AD:68D650BE)
```