### PR TITLE
add packages write permissions for the token

### DIFF
--- a/.github/workflows/push-main-docker.yml
+++ b/.github/workflows/push-main-docker.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   docker-build-and-push:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
 
     steps:
     - name: Checkout code


### PR DESCRIPTION
That will fix:
```
ERROR: failed to build: failed to solve: failed to push ghcr.io/neondatabase/gh-workflow-stats-action-history-exporter:latest: denied: installation not allowed to Write organization package
Error: buildx failed with: ERROR: failed to build: failed to solve: failed to push ghcr.io/neondatabase/gh-workflow-stats-action-history-exporter:latest: denied: installation not allowed to Write organization package
```
https://github.com/neondatabase/gh-workflow-stats-action/actions/runs/18033726723/job/51315790506